### PR TITLE
Feature/cvsb 6660

### DIFF
--- a/src/config/config.yml
+++ b/src/config/config.yml
@@ -5,11 +5,16 @@ invoke:
       endpoint: http://localhost:3013
     functions:
       testResults:
-          name: cvs-svc-test-results
-          mock: tests/resources/test-results-200-response.json
+        name: cvs-svc-test-results
+        mock: tests/resources/test-results-200-response.json
+      getActivities:
+        name: cvs-svc-activities
+        mock: tests/resources/wait-time-response.json
   remote:
     params:
       apiVersion: 2015-03-31
     functions:
       testResults:
-          name: test-results-${BRANCH}
+        name: test-results-${BRANCH}
+      getActivities:
+        name: activities-${BRANCH}

--- a/src/functions/retroGen.ts
+++ b/src/functions/retroGen.ts
@@ -30,6 +30,7 @@ const retroGen = async (event: any, context?: Context, callback?: Callback): Pro
                 const tokenResponse = await sharepointAuthenticationService.getToken();
                 const accessToken = JSON.parse(tokenResponse).access_token;
                 const sharePointResponse = await sharePointService.upload(generationServiceResponse.fileName, generationServiceResponse. fileBuffer, accessToken);
+                console.log(`SharepointResponse: ${sharePointResponse}`);
                 return sharePointResponse;
             });
 

--- a/src/models/enums.ts
+++ b/src/models/enums.ts
@@ -1,6 +1,7 @@
 export enum ActivityType {
     TEST = "Test",
-    WAIT_TIME = "Wait Time"
+    WAIT_TIME = "Wait Time",
+    TIME_NOT_TESTING = "Time not Testing"
 }
 
 export enum TimeZone {

--- a/src/models/index.d.ts
+++ b/src/models/index.d.ts
@@ -24,11 +24,41 @@ interface IActivity {
     testerStaffId: string;
     startTime: string;
     endTime: string;
+    waitReason: [string];
+    notes: string;
+}
+
+interface ITestType {
+    testTypeStartTimestamp: string;
+    testTypeName: string;
+    testResult: string;
+    certificateNumber: string;
+    testExpiryDate: number;
+    testTypeEndTimeStamp: string;
+}
+
+interface ITestResults {
+    testerStaffId: string;
+    vrm: string;
+    testStationPNumber: string;
+    preparerId: string;
+    numberOfSeats: number;
+    testStartTimestamp: string;
+    testEndTimestamp: string;
+    testTypes: ITestType;
+    vin: string;
+    vehicleType: string;
+}
+
+interface IActivitiesList {
+    startTime: string;
+    activityType: string;
+    activity: any;
 }
 
 interface IInvokeConfig {
     params: { apiVersion: string; endpoint?: string; };
-    functions: { testResults: { name: string }, techRecords: { name: string; mock: string } };
+    functions: { testResults: { name: string }, techRecords: { name: string; mock: string }, getActivities: { name: string }  };
 }
 
-export {ISPConfig, IActivity, IInvokeConfig};
+export {ISPConfig, IActivity, IInvokeConfig, ITestType, ITestResults, IActivitiesList};

--- a/src/services/ActivitiesService.ts
+++ b/src/services/ActivitiesService.ts
@@ -1,0 +1,60 @@
+import {IInvokeConfig} from "../models";
+import {PromiseResult} from "aws-sdk/lib/request";
+import {AWSError, Lambda} from "aws-sdk";
+import {LambdaService} from "./LambdaService";
+import {Configuration} from "../utils/Configuration";
+import moment from "moment";
+import {Service} from "../models/injector/ServiceDecorator";
+
+@Service()
+class ActivitiesService {
+    private readonly lambdaClient: LambdaService;
+    private readonly config: Configuration;
+
+    constructor(lambdaClient: LambdaService) {
+        this.lambdaClient = lambdaClient;
+        this.config = Configuration.getInstance();
+    }
+
+    /**
+     * Retrieves Activities based on the provided parameters
+     * @param params - getActivities query parameters
+     */
+    public getActivities(params: any): Promise<any> {
+        const config: IInvokeConfig = this.config.getInvokeConfig();
+        const invokeParams: any = {
+            FunctionName: config.functions.getActivities.name,
+            InvocationType: "RequestResponse",
+            LogType: "Tail",
+            Payload: JSON.stringify({
+                httpMethod: "GET",
+                path: "/activities/details",
+                queryStringParameters: params
+            }),
+        };
+        return this.lambdaClient.invoke(invokeParams)
+        .then((response: PromiseResult<Lambda.Types.InvocationResponse, AWSError>) => {
+            const payload: any = this.lambdaClient.validateInvocationResponse(response); // Response validation
+            const activityResults: any[] = JSON.parse(payload.body); // Response conversion
+            console.log(`Wait Activities: ${activityResults.length}`);
+
+            // Sort results by startTime
+            activityResults.sort((first: any, second: any): number => {
+                if (moment(first.startTime).isBefore(second.startTime)) {
+                    return -1;
+                }
+
+                if (moment(first.startTime).isAfter(second.startTime)) {
+                    return 1;
+                }
+
+                return 0;
+            });
+
+            return activityResults;
+        });
+    }
+
+}
+
+export { ActivitiesService };

--- a/tests/resources/wait-time-response.json
+++ b/tests/resources/wait-time-response.json
@@ -1,0 +1,8 @@
+{
+  "headers": {
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Credentials": true
+  },
+  "statusCode": 200,
+  "body": "[{\"startTime\":\"2019-01-14T10:37:33.987Z\",\"endTime\":\"2019-01-14T10:43:33.987Z\",\"waitReason\":\"Break\"}, {\"startTime\":\"2019-01-14T10:52:33.987Z\",\"endTime\":\"2019-01-14T10:58:33.987Z\",\"waitReason\":\"Others\",\"notes\":\"Documentation Delay\"}]"
+}


### PR DESCRIPTION
Changes done to include wait activities in retro-gen report.
Logic Impl: Adding testResults and waitActivities fetched for a visit into a common list and then sorting them based on startTime. And then this list is used to populate the data in the report.

Tested on AWS and reports look as expected. Added unit-tests to verify these additional wait activities. Please review and provide comments if any.