### PR TITLE
feat(vta-737): added potf to enum

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12195,9 +12195,9 @@
       }
     },
     "moment": {
-      "version": "2.29.2",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.2.tgz",
-      "integrity": "sha512-UgzG4rvxYpN15jgCmVJwac49h9ly9NurikMWGPdVxm8GZD6XjkKPxDTjQQ43gtGgnV3X0cAyWDdP2Wexoquifg=="
+      "version": "2.29.4",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w=="
     },
     "moment-timezone": {
       "version": "0.5.27",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "aws-xray-sdk": "^3.3.4",
     "exceljs": "^4.3.0",
     "js-yaml": "^3.13.1",
-    "moment": "^2.29.2",
+    "moment": "^2.29.4",
     "moment-timezone": "^0.5.27",
     "node-yaml": "^4.0.1",
     "request": "^2.88.0",

--- a/src/models/index.d.ts
+++ b/src/models/index.d.ts
@@ -2,6 +2,7 @@ declare enum StationType {
   ATF = "atf",
   GVTS = "gvts",
   HQ = "hq",
+  POTF = "potf"
 }
 
 interface ISPConfig {


### PR DESCRIPTION
## Allow POTF testStationTypes to be used when starting visit in VTA

Update the service to allow potf testStationType to be used when starting a visit.
[https://dvsa.atlassian.net/browse/VTA-737](VTA-737)

## Checklist

- [X] Code has been tested manually
- [X] PR title includes the JIRA ticket number
- [X] Branch is rebased against the latest develop
- [ ] Squashed commit contains the JIRA ticket number