### PR TITLE
VTA-298: Linked LEC tests - PSV does not show without linked test

### DIFF
--- a/src/services/RetroGenerationService.ts
+++ b/src/services/RetroGenerationService.ts
@@ -376,7 +376,7 @@ class RetroGenerationService {
    * @param testType
    */
   private isPassingLECTestType(testType: any): boolean {
-    const lecTestTypeIds = ["39", "44", "45"];
+    const lecTestTypeIds = ["39", "201", "44", "45"];
     return lecTestTypeIds.includes(testType.testTypeId) && testType.testResult === TEST_RESULT_STATES.PASS;
   }
 }


### PR DESCRIPTION
## Linked LEC tests - PSV does not show without linked test

Updated lecTestTypeIds array to include the addition of 201 (PSV LEC without linked test)
[VTA-298](https://dvsa.atlassian.net/browse/VTA-298)

## Checklist

- [X] Branch is rebased against the latest develop
- [X] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [X] Link to the PR added to the repo
